### PR TITLE
Fix assertFailure bug in JsonSerializableAddressBookTest.java

### DIFF
--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -4,42 +4,42 @@
     "name" : "Alice Pauline",
     "phone" : "94351253",
     "email" : "alice@example.com",
-    "username" : "alice-123",
+    "username" : "alice-paul",
     "tagged" : [ "friends" ],
     "skillSet" : [ "C_50" ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
     "email" : "johnd@example.com",
-    "username" : "benson",
+    "username" : "benson-123",
     "tagged" : [ "owesMoney", "friends" ],
     "skillSet" : [ "python_40" ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "heinz@example.com",
-    "username" : "kurlz99",
+    "username" : "kurz-carl",
     "tagged" : [ ],
     "skillSet" : [ ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
     "email" : "cornelia@example.com",
-    "username" : "meier",
+    "username" : "meier-coding",
     "tagged" : [ "friends" ],
     "skillSet" : [ "Bash_90" ]
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
     "email" : "werner@example.com",
-    "username" : "elle0123",
+    "username" : "ellelle",
     "tagged" : [ ],
     "skillSet" : [ "C_50" ]
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
     "email" : "lydia@example.com",
-    "username" : "fiona",
+    "username" : "kunzgunz",
     "tagged" : [ ],
     "skillSet" : [ "Git_59" ]
   }, {

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -29,7 +29,7 @@ public class JsonSerializableAddressBookTest {
                 JsonSerializableAddressBook.class).get();
         AddressBook addressBookFromFile = dataFromFile.toModelType();
         AddressBook typicalPersonsAddressBook = TypicalPersons.getTypicalAddressBook();
-        assertEquals(addressBookFromFile.toString(), typicalPersonsAddressBook.toString());
+        assertEquals(addressBookFromFile, typicalPersonsAddressBook);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -21,8 +21,6 @@ public class PersonBuilder {
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_USERNAME = "amybee99";
-    public static final String DEFAULT_TAG = "friend";
-    public static final String DEFAULT_SKILL = "Python_33";
 
     private Name name;
     private Phone phone;
@@ -41,8 +39,6 @@ public class PersonBuilder {
         githubUsername = new GithubUsername(DEFAULT_USERNAME);
         tags = new HashSet<>();
         skillSet = new HashSet<>();
-        withSkillSet(DEFAULT_SKILL);
-        withTags(DEFAULT_TAG);
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -58,7 +58,7 @@ public class PersonUtil {
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {
-                sb.append(PREFIX_TAG);
+                sb.append(PREFIX_TAG).append(" ");
             } else {
                 tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
             }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -35,17 +35,30 @@ public class TypicalPersons {
             .withEmail("johnd@example.com").withPhone("98765432")
             .withTags("owesMoney", "friends")
             .withSkillSet("python_40").build();
-    public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withGithubUsername("kurz-carl").build();
-    public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withGithubUsername("meier-coding")
+    public static final Person CARL = new PersonBuilder().withName("Carl Kurz")
+            .withPhone("95352563")
+            .withEmail("heinz@example.com")
+            .withGithubUsername("kurz-carl").build();
+    public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier")
+            .withPhone("87652533")
+            .withEmail("cornelia@example.com")
+            .withGithubUsername("meier-coding")
             .withTags("friends").withSkillSet("Bash_90").build();
-    public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withGithubUsername("ellelle").withSkillSet("C_50").build();
-    public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withGithubUsername("kunzgunz").withSkillSet("Git_59").build();
-    public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withGithubUsername("best-coder").withSkillSet("C_50").build();
+    public static final Person ELLE = new PersonBuilder().withName("Elle Meyer")
+            .withPhone("9482224")
+            .withEmail("werner@example.com")
+            .withGithubUsername("ellelle")
+            .withSkillSet("C_50").build();
+    public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz")
+            .withPhone("9482427")
+            .withEmail("lydia@example.com")
+            .withGithubUsername("kunzgunz")
+            .withSkillSet("Git_59").build();
+    public static final Person GEORGE = new PersonBuilder().withName("George Best")
+            .withPhone("9482442")
+            .withEmail("anna@example.com")
+            .withGithubUsername("best-coder")
+            .withSkillSet("C_50").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")


### PR DESCRIPTION
Fix assertFailure bug in JsonSerializableAddressBookTest.java on changing  `assertEquals(addressBookFromFile, typicalPersonsAddressBook);` instead of `assertEquals(addressBookFromFile.toString(), typicalPersonsAddressBook.toString());`

Bugs:
1. Values in `typicalPersonsAddressBook.json` does not equal to values assigned in `TypicalPersons.java`.
    * The values created in `TypicalPersons.java` do not match the values saved in `typicalPersonsAddressBook.json`, causing Persons with different information to be created, causing assertFailure on test run.
3. Default tags and skills are created although they do not exist in `JsonSerializableAddressBookTest.java`.
    * Default values initialized in `PersonBuilder.java` caused default tags to be created. If tags are empty in `typicalPersonsAddressBook.json`, default values get created, causing test to fail.
5. `PersonUtil::getEditPersonDescriptorDetails` missing whitespace to separate tag and skills.
    * `PersonUtil::getEditPersonDescriptorDetails` is previously set to accept tags as the last parameter. As we added a new `Skill` field, the lack of whitespace caused the descriptor to create 't/s/' at the end of the string. This string gets parsed by the parser which throws a ParseException when it tries to parse 's/' as a tag, failing the validation regex in `Tag.java`.

Fixes: https://github.com/AY2122S2-CS2103T-W13-3/tp/issues/34