### PR TITLE
Fix bug on Filter feature on multiple skill inputs

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FilterSkillCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterSkillCommandParser.java
@@ -2,10 +2,14 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import seedu.address.logic.commands.FilterSkillCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.PersonContainsSkillPredicate;
 import seedu.address.model.team.Skill;
+import seedu.address.model.team.SkillSet;
 
 /**
  * Parses input arguments and creates a new FilterSkillCommand object
@@ -24,9 +28,13 @@ public class FilterSkillCommandParser implements Parser<FilterSkillCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterSkillCommand.MESSAGE_USAGE));
         }
 
-        Skill skill = new Skill(trimmedArgs);
+        String[] keywords = trimmedArgs.split("\\s+");
 
-        return new FilterSkillCommand(new PersonContainsSkillPredicate(skill));
+        SkillSet skillSet = new SkillSet(Arrays.stream(keywords)
+                .map(Skill::new)
+                .collect(Collectors.toSet()));
+
+        return new FilterSkillCommand(new PersonContainsSkillPredicate(skillSet));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -2,8 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.HashSet;
-
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.PersonBySkillProficiencyComparator;
@@ -29,9 +27,9 @@ public class SortCommandParser implements Parser<SortCommand> {
         }
 
         Skill skillToFilter = new Skill(trimmedArgs);
-        HashSet<Skill> skillSet = new HashSet<>();
+        SkillSet skillSet = new SkillSet();
         skillSet.add(skillToFilter);
-        PersonContainsSkillPredicate predicate = new PersonContainsSkillPredicate(new SkillSet(skillSet));
+        PersonContainsSkillPredicate predicate = new PersonContainsSkillPredicate(skillSet);
         PersonBySkillProficiencyComparator comparator = new PersonBySkillProficiencyComparator(skillToFilter);
 
         return new SortCommand(predicate, comparator);

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -2,11 +2,14 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.HashSet;
+
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.PersonBySkillProficiencyComparator;
 import seedu.address.model.person.PersonContainsSkillPredicate;
 import seedu.address.model.team.Skill;
+import seedu.address.model.team.SkillSet;
 
 /**
  * Parses input arguments and creates a new SortCommand object
@@ -26,7 +29,9 @@ public class SortCommandParser implements Parser<SortCommand> {
         }
 
         Skill skillToFilter = new Skill(trimmedArgs);
-        PersonContainsSkillPredicate predicate = new PersonContainsSkillPredicate(skillToFilter);
+        HashSet<Skill> skillSet = new HashSet<>();
+        skillSet.add(skillToFilter);
+        PersonContainsSkillPredicate predicate = new PersonContainsSkillPredicate(new SkillSet(skillSet));
         PersonBySkillProficiencyComparator comparator = new PersonBySkillProficiencyComparator(skillToFilter);
 
         return new SortCommand(predicate, comparator);

--- a/src/main/java/seedu/address/model/person/PersonContainsSkillPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsSkillPredicate.java
@@ -2,28 +2,32 @@ package seedu.address.model.person;
 
 import java.util.function.Predicate;
 
-import seedu.address.model.team.Skill;
+import seedu.address.model.team.SkillSet;
 
 /**
  * Tests that a {@code Person}'s {@code Skill} matches any of the keywords given.
  */
 public class PersonContainsSkillPredicate implements Predicate<Person> {
-    private final Skill skill;
+    private final SkillSet skillSet;
 
-    public PersonContainsSkillPredicate(Skill skill) {
-        this.skill = skill;
+    /**
+     *
+     * @param skillSet
+     */
+    public PersonContainsSkillPredicate(SkillSet skillSet) {
+        this.skillSet = skillSet;
     }
 
     @Override
     public boolean test(Person person) {
-        return person.hasSkill(this.skill);
+        return person.getSkillSet().hasSkills(this.skillSet);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof PersonContainsSkillPredicate // instanceof handles nulls
-                && skill.equals(((PersonContainsSkillPredicate) other).skill)); // state check
+                && skillSet.hasSameSkillSet(((PersonContainsSkillPredicate) other).skillSet)); // state check
     }
 
 }

--- a/src/main/java/seedu/address/model/team/SkillSet.java
+++ b/src/main/java/seedu/address/model/team/SkillSet.java
@@ -71,8 +71,8 @@ public class SkillSet {
      */
     public boolean hasSkills(SkillSet skillset) {
         requireAllNonNull(skillset);
-        return skillset.skillSet.stream()
-                .allMatch(x -> this.hasSkill(x));
+        return skillset.getSkillSetInStream()
+                .allMatch((this::hasSkill));
     }
 
     /**

--- a/src/main/java/seedu/address/model/team/SkillSet.java
+++ b/src/main/java/seedu/address/model/team/SkillSet.java
@@ -64,6 +64,18 @@ public class SkillSet {
     }
 
     /**
+     * Returns true if the current SkillSet has all the skills inside the provided SkillSet.
+     *
+     * @param skillset The SkillSet that contains all the skills that this SkillSet must possess.
+     * @return True if this SkillSet contains all the skills, false otherwise.
+     */
+    public boolean hasSkills(SkillSet skillset) {
+        requireAllNonNull(skillset);
+        return skillset.skillSet.stream()
+                .allMatch(x -> this.hasSkill(x));
+    }
+
+    /**
      * Adds all of provided skillSet into this skillSet
      * @param additionalSkill skillSet to be added
      */

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -7,7 +7,7 @@
     "username" : "alice-paul",
     "isPotentialTeammate": false,
     "teams" : [ "friends" ],
-    "skillSet" : [ "C_20" ]
+    "skillSet" : [ "C_20" , "Python_40"]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",

--- a/src/test/java/seedu/address/logic/commands/FilterSkillCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterSkillCommandTest.java
@@ -20,6 +20,7 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.PersonContainsSkillPredicate;
 import seedu.address.model.team.Skill;
+import seedu.address.model.team.SkillSet;
 
 class FilterSkillCommandTest {
 
@@ -28,14 +29,24 @@ class FilterSkillCommandTest {
 
     @Test
     public void equals() {
+
+        SkillSet skillSet1 = new SkillSet();
+        skillSet1.add(new Skill("skill1", 40));
+        SkillSet skillSet2 = new SkillSet();
+        skillSet2.add(new Skill("skill2"));
+        SkillSet skillSet3 = new SkillSet();
+        skillSet3.add(new Skill("skill1", 90));
+
         PersonContainsSkillPredicate firstPredicate =
-                new PersonContainsSkillPredicate(new Skill("skill1"));
+                new PersonContainsSkillPredicate(skillSet1);
         PersonContainsSkillPredicate secondPredicate =
-                new PersonContainsSkillPredicate(new Skill("skill2"));
+                new PersonContainsSkillPredicate(skillSet2);
+        PersonContainsSkillPredicate thirdPredicate =
+                new PersonContainsSkillPredicate(skillSet3);
 
         FilterSkillCommand filterFirstSkillCommand = new FilterSkillCommand(firstPredicate);
         FilterSkillCommand filterSecondSkillCommand = new FilterSkillCommand(secondPredicate);
-
+        FilterSkillCommand filterThirdSkillCommand = new FilterSkillCommand(thirdPredicate);
 
         // same object -> returns true
         assertTrue(filterFirstSkillCommand.equals(filterFirstSkillCommand));
@@ -43,6 +54,9 @@ class FilterSkillCommandTest {
         // same values -> returns true
         FilterSkillCommand filterFirstSkillCommandCopy = new FilterSkillCommand(firstPredicate);
         assertTrue(filterFirstSkillCommandCopy.equals(filterFirstSkillCommandCopy));
+
+        // same skills, different proficiency -> returns true
+        assertTrue(filterFirstSkillCommand.equals(filterThirdSkillCommand));
 
         // different types -> returns false
         assertFalse(filterFirstSkillCommand.equals(1));
@@ -75,9 +89,11 @@ class FilterSkillCommandTest {
     }
 
     /**
-     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     * Parses {@code userInput} into a {@code PersonContainsSkillPredicate}.
      */
     private PersonContainsSkillPredicate preparePredicate(String userInput) {
-        return new PersonContainsSkillPredicate(new Skill(userInput));
+        SkillSet skillSet = new SkillSet();
+        skillSet.add(new Skill(userInput));
+        return new PersonContainsSkillPredicate(skillSet);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -21,6 +21,7 @@ import seedu.address.model.UserPrefs;
 import seedu.address.model.person.PersonBySkillProficiencyComparator;
 import seedu.address.model.person.PersonContainsSkillPredicate;
 import seedu.address.model.team.Skill;
+import seedu.address.model.team.SkillSet;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code SortCommand}.
@@ -31,11 +32,17 @@ class SortCommandTest {
 
     @Test
     public void equals() {
+        SkillSet skillSet1 = new SkillSet();
+        SkillSet skillSet2 = new SkillSet();
+
         Skill firstSkill = new Skill("Java");
         Skill secondSkill = new Skill("C");
 
-        PersonContainsSkillPredicate firstPredicate = new PersonContainsSkillPredicate(firstSkill);
-        PersonContainsSkillPredicate secondPredicate = new PersonContainsSkillPredicate(secondSkill);
+        skillSet1.add(firstSkill);
+        skillSet2.add(secondSkill);
+
+        PersonContainsSkillPredicate firstPredicate = new PersonContainsSkillPredicate(skillSet1);
+        PersonContainsSkillPredicate secondPredicate = new PersonContainsSkillPredicate(skillSet2);
 
         PersonBySkillProficiencyComparator firstComp = new PersonBySkillProficiencyComparator(firstSkill);
         PersonBySkillProficiencyComparator secondComp = new PersonBySkillProficiencyComparator(secondSkill);
@@ -63,8 +70,11 @@ class SortCommandTest {
 
     @Test
     public void execute_invalidSkill_noPersonFound() {
+        SkillSet invalidSkillSet = new SkillSet();
         Skill invalidSkill = new Skill("abcdef");
-        PersonContainsSkillPredicate predicate = new PersonContainsSkillPredicate(invalidSkill);
+        invalidSkillSet.add(invalidSkill);
+
+        PersonContainsSkillPredicate predicate = new PersonContainsSkillPredicate(invalidSkillSet);
         PersonBySkillProficiencyComparator comp = new PersonBySkillProficiencyComparator(invalidSkill);
         SortCommand command = new SortCommand(predicate, comp);
 
@@ -76,8 +86,11 @@ class SortCommandTest {
 
     @Test
     public void execute_validSkill_filtersAndSortsDisplayPersonList() {
+        SkillSet skillSet = new SkillSet();
         Skill skill = new Skill("C");
-        PersonContainsSkillPredicate predicate = new PersonContainsSkillPredicate(skill);
+        skillSet.add(skill);
+
+        PersonContainsSkillPredicate predicate = new PersonContainsSkillPredicate(skillSet);
         PersonBySkillProficiencyComparator comp = new PersonBySkillProficiencyComparator(skill);
         SortCommand command = new SortCommand(predicate, comp);
 

--- a/src/test/java/seedu/address/logic/parser/FilterSkillCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterSkillCommandParserTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.FilterSkillCommand;
 import seedu.address.model.person.PersonContainsSkillPredicate;
 import seedu.address.model.team.Skill;
+import seedu.address.model.team.SkillSet;
 
 class FilterSkillCommandParserTest {
 
@@ -23,8 +24,11 @@ class FilterSkillCommandParserTest {
     @Test
     public void parse_validArgs_returnsFilterSkillCommand() {
         // no leading and trailing whitespaces
+        SkillSet skillSet = new SkillSet();
+        skillSet.add(new Skill("C"));
+
         FilterSkillCommand expectedFilterSkillCommand =
-                new FilterSkillCommand(new PersonContainsSkillPredicate(new Skill("C")));
+                new FilterSkillCommand(new PersonContainsSkillPredicate(skillSet));
         assertParseSuccess(parser, "C", expectedFilterSkillCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -10,6 +10,7 @@ import seedu.address.logic.commands.SortCommand;
 import seedu.address.model.person.PersonBySkillProficiencyComparator;
 import seedu.address.model.person.PersonContainsSkillPredicate;
 import seedu.address.model.team.Skill;
+import seedu.address.model.team.SkillSet;
 
 class SortCommandParserTest {
 
@@ -23,8 +24,11 @@ class SortCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsSortCommand() {
+        SkillSet skillSet = new SkillSet();
         Skill skill = new Skill("Java");
-        SortCommand expectedSortCommand = new SortCommand(new PersonContainsSkillPredicate(skill),
+        skillSet.add(skill);
+
+        SortCommand expectedSortCommand = new SortCommand(new PersonContainsSkillPredicate(skillSet),
             new PersonBySkillProficiencyComparator(skill));
 
         assertParseSuccess(parser, "Java", expectedSortCommand);

--- a/src/test/java/seedu/address/model/person/PersonContainsSkillPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonContainsSkillPredicateTest.java
@@ -2,8 +2,10 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalSkills.SKILL_C_0;
-import static seedu.address.testutil.TypicalSkills.SKILL_C_NULL;
+import static seedu.address.testutil.TypicalSkills.SKILL_C_20;
 import static seedu.address.testutil.TypicalSkills.SKILL_JAVA_40;
 import static seedu.address.testutil.TypicalSkills.SKILL_JAVA_50;
 import static seedu.address.testutil.TypicalSkills.SKILL_PYTHON_30;
@@ -22,11 +24,11 @@ class PersonContainsSkillPredicateTest {
 
         SkillSet skillSet2 = new SkillSet();
         skillSet2.add(SKILL_JAVA_40);
-        skillSet2.add(SKILL_C_NULL);
+        skillSet2.add(SKILL_C_20);
 
         SkillSet skillSet3 = new SkillSet();
         skillSet3.add(SKILL_JAVA_40);
-        skillSet3.add(SKILL_C_NULL);
+        skillSet3.add(SKILL_C_20);
         skillSet3.add(SKILL_PYTHON_30);
 
         PersonContainsSkillPredicate firstPredicate = new PersonContainsSkillPredicate(skillSet1);
@@ -45,6 +47,57 @@ class PersonContainsSkillPredicateTest {
         assertTrue(firstPredicate.equals(secondPredicate));
 
         //additional skill in one skillSet -> returns false
-        assertFalse(skillSet2.equals(skillSet3));
+        assertFalse(fourthPredicate.equals(thirdPredicate));
     }
+
+
+    @Test
+    void test_personContainsSomeSkills_returnFalse() {
+        SkillSet skillSetPythonC = new SkillSet();
+        skillSetPythonC.add(SKILL_PYTHON_30);
+        skillSetPythonC.add(SKILL_C_20);
+
+        PersonContainsSkillPredicate personContainsPythonCPredicate = new PersonContainsSkillPredicate(skillSetPythonC);
+
+        assertFalse(personContainsPythonCPredicate.test(BENSON));
+    }
+
+    @Test
+    void test_personContainsAllSkills_returnFalse() {
+        SkillSet skillSetPythonC = new SkillSet();
+        skillSetPythonC.add(SKILL_PYTHON_30);
+        skillSetPythonC.add(SKILL_C_20);
+
+        PersonContainsSkillPredicate personContainsPythonCPredicate = new PersonContainsSkillPredicate(skillSetPythonC);
+
+        assertTrue(personContainsPythonCPredicate.test(ALICE));
+    }
+
+    @Test
+    void test_personContainsSkill_returnTrue() {
+        SkillSet skillSetC = new SkillSet();
+        skillSetC.add(SKILL_C_20);
+
+        SkillSet skillSetPython = new SkillSet();
+        skillSetPython.add(SKILL_PYTHON_30);
+
+        PersonContainsSkillPredicate personContainsCPredicate = new PersonContainsSkillPredicate(skillSetC);
+        PersonContainsSkillPredicate personContainsPythonPredicate = new PersonContainsSkillPredicate(skillSetPython);
+
+        assertTrue(personContainsCPredicate.test(ALICE));
+        assertTrue(personContainsPythonPredicate.test(ALICE));
+        assertTrue(personContainsPythonPredicate.test(BENSON));
+    }
+
+    @Test
+    void test_personDoesNotContainsSkill_returnFalse() {
+        SkillSet skillSetJava = new SkillSet();
+        skillSetJava.add(SKILL_JAVA_40);
+
+        PersonContainsSkillPredicate personContainsJavaPredicate = new PersonContainsSkillPredicate(skillSetJava);
+
+        assertFalse(personContainsJavaPredicate.test(BENSON));
+        assertFalse(personContainsJavaPredicate.test(ALICE));
+    }
+
 }

--- a/src/test/java/seedu/address/model/person/PersonContainsSkillPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonContainsSkillPredicateTest.java
@@ -1,0 +1,50 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalSkills.SKILL_C_0;
+import static seedu.address.testutil.TypicalSkills.SKILL_C_NULL;
+import static seedu.address.testutil.TypicalSkills.SKILL_JAVA_40;
+import static seedu.address.testutil.TypicalSkills.SKILL_JAVA_50;
+import static seedu.address.testutil.TypicalSkills.SKILL_PYTHON_30;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.team.SkillSet;
+
+class PersonContainsSkillPredicateTest {
+
+    @Test
+    void testEquals() {
+        SkillSet skillSet1 = new SkillSet();
+        skillSet1.add(SKILL_JAVA_50);
+        skillSet1.add(SKILL_C_0);
+
+        SkillSet skillSet2 = new SkillSet();
+        skillSet2.add(SKILL_JAVA_40);
+        skillSet2.add(SKILL_C_NULL);
+
+        SkillSet skillSet3 = new SkillSet();
+        skillSet3.add(SKILL_JAVA_40);
+        skillSet3.add(SKILL_C_NULL);
+        skillSet3.add(SKILL_PYTHON_30);
+
+        PersonContainsSkillPredicate firstPredicate = new PersonContainsSkillPredicate(skillSet1);
+        PersonContainsSkillPredicate secondPredicate = new PersonContainsSkillPredicate(skillSet2);
+        PersonContainsSkillPredicate thirdPredicate = new PersonContainsSkillPredicate(skillSet2);
+        PersonContainsSkillPredicate fourthPredicate = new PersonContainsSkillPredicate(skillSet3);
+
+
+        //same object -> return true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        //same skillSet reference -> returns true
+        assertTrue(secondPredicate.equals(thirdPredicate));
+
+        //same skills in skillset with different proficiency -> returns true
+        assertTrue(firstPredicate.equals(secondPredicate));
+
+        //additional skill in one skillSet -> returns false
+        assertFalse(skillSet2.equals(skillSet3));
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -29,7 +29,7 @@ public class TypicalPersons {
             .withGithubUsername("alice-paul").withEmail("alice@example.com")
             .withPhone("94351253")
             .withTeams("friends")
-            .withSkillSet("C_20")
+            .withSkillSet("C_20", "Python_40")
             .isPotentialTeammate(false)
             .build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")

--- a/src/test/java/seedu/address/testutil/TypicalSkills.java
+++ b/src/test/java/seedu/address/testutil/TypicalSkills.java
@@ -8,7 +8,7 @@ import seedu.address.model.team.Skill;
 public class TypicalSkills {
     public static final Skill SKILL_JAVA_50 = new Skill("Java", 50);
     public static final Skill SKILL_JAVA_40 = new Skill("Java", 40);
-    public static final Skill SKILL_C_NULL = new Skill("C");
+    public static final Skill SKILL_C_20 = new Skill("C", 20);
     public static final Skill SKILL_C_0 = new Skill("C", 0);
     public static final Skill SKILL_PYTHON_30 = new Skill("PYTHON", 30);
 }

--- a/src/test/java/seedu/address/testutil/TypicalSkills.java
+++ b/src/test/java/seedu/address/testutil/TypicalSkills.java
@@ -1,0 +1,14 @@
+package seedu.address.testutil;
+
+import seedu.address.model.team.Skill;
+
+/**
+ * A utility class containing a list of {@code Skill} objects to be used in tests.
+ */
+public class TypicalSkills {
+    public static final Skill SKILL_JAVA_50 = new Skill("Java", 50);
+    public static final Skill SKILL_JAVA_40 = new Skill("Java", 40);
+    public static final Skill SKILL_C_NULL = new Skill("C");
+    public static final Skill SKILL_C_0 = new Skill("C", 0);
+    public static final Skill SKILL_PYTHON_30 = new Skill("PYTHON", 30);
+}


### PR DESCRIPTION
Filter and Sort command has a bug that is unresponsive when the user
enters the filter or sort command with multiple skills or skills with
non-alphanumeric characters.

Filter Command now accepts multiple skills as filter criteria.

Additional tests and testutils are also added in this commit.

Partially fixes #56