### PR TITLE
Add input validation for `Skill` field and GUI error feedback to user

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -121,13 +121,19 @@ public class ParserUtil {
     public static Skill parseSkill(String skill) throws ParseException {
         requireNonNull(skill);
         String[] trimmedSkill = skill.trim().split("_");
+        if (trimmedSkill.length != 2) {
+            throw new ParseException(Skill.SKILL_INPUT_CONSTRAINTS);
+        }
         String skillName = trimmedSkill[0];
+        if (!Skill.isValidSkillProficiencyInteger(trimmedSkill[1])) {
+            throw new ParseException(Skill.PROFICIENCY_CONSTRAINTS_INTEGER);
+        }
         int skillProficiency = Integer.parseInt(trimmedSkill[1]);
         if (!Skill.isValidSkillName(skillName)) {
             throw new ParseException(Skill.NAME_CONSTRAINTS);
         }
-        if (!Skill.isValidSkillProficiency(skillProficiency)) {
-            throw new ParseException(Skill.PROFICIENCY_CONSTRAINTS);
+        if (!Skill.isValidSkillProficiencyRange(skillProficiency)) {
+            throw new ParseException(Skill.PROFICIENCY_CONSTRAINTS_RANGE);
         }
         return new Skill(skillName, skillProficiency);
     }

--- a/src/main/java/seedu/address/model/team/Skill.java
+++ b/src/main/java/seedu/address/model/team/Skill.java
@@ -11,8 +11,12 @@ public class Skill {
 
     public static final String NAME_CONSTRAINTS = "Skill names should be alphanumeric";
     public static final String NAME_VALIDATION_REGEX = "\\p{Alnum}+";
-    public static final String PROFICIENCY_CONSTRAINTS = "Skill proficiency should be within range of 1-100";
-    public static final String PROFICIENCY_VALIDATION_REGEX = "^[0-9]$|^[1-9][0-9]$|^(100)$";
+    public static final String PROFICIENCY_CONSTRAINTS_RANGE = "Skill proficiency should be within range of 1-100";
+    public static final String PROFICIENCY_CONSTRAINTS_INTEGER = "Skill proficiency must be an integer";
+    public static final String PROFICIENCY_VALIDATION_BETWEEN_0_TO_100 = "^[0-9]$|^[1-9][0-9]$|^(100)$";
+    public static final String PROFICIENCY_VALIDATION_ONLY_INTEGERS = "^[0-9]+$";
+    public static final String SKILL_INPUT_CONSTRAINTS = "Skill input should be: Skill Name_Skill proficiency. eg: "
+            + "Java_50";
 
     public final String skillName;
     public final int skillProficiency;
@@ -25,9 +29,8 @@ public class Skill {
      */
     public Skill(String skillName, int skillProficiency) {
         requireNonNull(skillName);
-        requireNonNull(skillProficiency);
         checkArgument(isValidSkillName(skillName), NAME_CONSTRAINTS);
-        checkArgument(isValidSkillProficiency(skillProficiency), PROFICIENCY_CONSTRAINTS);
+        checkArgument(isValidSkillProficiencyRange(skillProficiency), PROFICIENCY_CONSTRAINTS_RANGE);
         this.skillName = skillName;
         this.skillProficiency = skillProficiency;
     }
@@ -54,9 +57,16 @@ public class Skill {
     /**
      * Returns true if a given int is a valid skill proficiency level.
      */
-    public static boolean isValidSkillProficiency(int test) {
+    public static boolean isValidSkillProficiencyRange(int test) {
         String testInt = String.valueOf(test);
-        return testInt.matches(PROFICIENCY_VALIDATION_REGEX);
+        return testInt.matches(PROFICIENCY_VALIDATION_BETWEEN_0_TO_100);
+    }
+
+    /**
+     * Returns true if given String contains only integers
+     */
+    public static boolean isValidSkillProficiencyInteger(String test) {
+        return test.matches(PROFICIENCY_VALIDATION_ONLY_INTEGERS);
     }
 
     public boolean isSameSkill(Skill skill) {

--- a/src/main/java/seedu/address/storage/JsonAdaptedSkill.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedSkill.java
@@ -54,8 +54,8 @@ public class JsonAdaptedSkill {
         if (!Skill.isValidSkillName(skillName)) {
             throw new IllegalValueException(Skill.NAME_CONSTRAINTS);
         }
-        if (!Skill.isValidSkillProficiency(skillProficiency)) {
-            throw new IllegalValueException(Skill.PROFICIENCY_CONSTRAINTS);
+        if (!Skill.isValidSkillProficiencyRange(skillProficiency)) {
+            throw new IllegalValueException(Skill.PROFICIENCY_CONSTRAINTS_RANGE);
         }
         return new Skill(skillName, skillProficiency);
     }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -26,6 +26,8 @@ public class ParserUtilTest {
     private static final String INVALID_USERNAME = "rach_el";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TEAM = "#friend";
+    private static final String INVALID_SKILL_PROFICIENCY_TYPE = "good";
+    private static final String INVALID_SKILL_PROFICIENCY_RANGE = "500";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -33,6 +35,10 @@ public class ParserUtilTest {
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TEAM_1 = "friend";
     private static final String VALID_TEAM_2 = "neighbour";
+    private static final String VALID_SKILL = "Python";
+    private static final String VALID_SKILL_PREFIX = "_";
+    private static final String VALID_SKILL_PROFICIENCY = "5";
+
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -192,5 +198,21 @@ public class ParserUtilTest {
         Set<Team> expectedTeamSet = new HashSet<Team>(Arrays.asList(new Team(VALID_TEAM_1), new Team(VALID_TEAM_2)));
 
         assertEquals(expectedTeamSet, actualTeamSet);
+    }
+
+    @Test
+    public void parseSkill_throwsParseException() throws Exception {
+        String invalidProficiencyRange = VALID_SKILL + VALID_SKILL_PREFIX + INVALID_SKILL_PROFICIENCY_RANGE;
+        String invalidProficiencyType = VALID_SKILL + VALID_SKILL_PREFIX + INVALID_SKILL_PROFICIENCY_TYPE;
+        String invalidSkillInput1 = VALID_SKILL + VALID_SKILL_PREFIX + VALID_SKILL_PROFICIENCY
+                + VALID_SKILL_PREFIX + VALID_SKILL;
+        String invalidSkillInput2 = VALID_SKILL + VALID_SKILL_PREFIX;
+        String invalidSkillInput3 = VALID_SKILL;
+
+        assertThrows(ParseException.class, ()-> ParserUtil.parseSkill(invalidProficiencyRange));
+        assertThrows(ParseException.class, ()-> ParserUtil.parseSkill(invalidProficiencyType));
+        assertThrows(ParseException.class, ()-> ParserUtil.parseSkill(invalidSkillInput1));
+        assertThrows(ParseException.class, ()-> ParserUtil.parseSkill(invalidSkillInput2));
+        assertThrows(ParseException.class, ()-> ParserUtil.parseSkill(invalidSkillInput3));
     }
 }

--- a/src/test/java/seedu/address/model/team/SkillTest.java
+++ b/src/test/java/seedu/address/model/team/SkillTest.java
@@ -72,11 +72,11 @@ public class SkillTest {
     }
 
     @Test void isValidSkillProficiency() {
-        assertTrue(Skill.isValidSkillProficiency(100));
-        assertTrue(Skill.isValidSkillProficiency(10));
-        assertTrue(Skill.isValidSkillProficiency(0));
-        assertFalse(Skill.isValidSkillProficiency(101));
-        assertFalse(Skill.isValidSkillProficiency(-1));
+        assertTrue(Skill.isValidSkillProficiencyRange(100));
+        assertTrue(Skill.isValidSkillProficiencyRange(10));
+        assertTrue(Skill.isValidSkillProficiencyRange(0));
+        assertFalse(Skill.isValidSkillProficiencyRange(101));
+        assertFalse(Skill.isValidSkillProficiencyRange(-1));
     }
 
 }


### PR DESCRIPTION
`Skill` did not display an error upon receiving invalid input and simply dropped the invalid user input.
This might cause confusion for the user when their input is ignored.

This commit implements the following checks
- Check if skill proficiency input is an integer
- Check for skill proficiency is in the range of integers from 0 - 100
- Check for valid String input combination: `SkillName_SkillProficiency`