### PR TITLE
Fix bug with sort command on invalid args

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -22,6 +22,8 @@ public class SortCommand extends Command {
             + "Parameters: SKILL\n"
             + "Example: " + COMMAND_WORD + " Java";
 
+    public static final String MESSAGE_INVALID_SKILL = "Invalid skill name: %s";
+
     private final PersonContainsSkillPredicate predicate;
 
     private final PersonBySkillProficiencyComparator comparator;

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -17,13 +17,17 @@ public class SortCommandParser implements Parser<SortCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the SortCommand
      * and returns a SortCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseException if the user input does not conform to the expected format
      */
     public SortCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        }
+
+        if (!Skill.isValidSkillName(trimmedArgs)) {
+            throw new ParseException(String.format(SortCommand.MESSAGE_INVALID_SKILL, Skill.NAME_CONSTRAINTS));
         }
 
         Skill skillToFilter = new Skill(trimmedArgs);

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -24,9 +24,14 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.MakeTeamCommand;
 import seedu.address.logic.commands.ShowCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonBySkillProficiencyComparator;
+import seedu.address.model.person.PersonContainsSkillPredicate;
+import seedu.address.model.team.Skill;
+import seedu.address.model.team.SkillSet;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -82,6 +87,18 @@ public class AddressBookParserTest {
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+    }
+
+    @Test
+    public void parseCommand_sort() throws Exception {
+        Skill skill = new Skill("C");
+        SkillSet skillSet = new SkillSet();
+        skillSet.add(skill);
+        PersonContainsSkillPredicate predicate = new PersonContainsSkillPredicate(skillSet);
+        PersonBySkillProficiencyComparator comparator = new PersonBySkillProficiencyComparator(skill);
+
+        SortCommand expectedCommand = new SortCommand(predicate, comparator);
+        assertEquals(expectedCommand, parser.parseCommand(SortCommand.COMMAND_WORD + " C"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -24,7 +24,7 @@ class SortCommandParserTest {
     }
 
     @Test
-    public void parse_invalidSkillName_throwsParseException() {
+    public void parse_invalidSkillInput_throwsParseException() {
         // Multiple skill name
         assertParseFailure(parser, "C Python", String.format(MESSAGE_INVALID_SKILL, Skill.NAME_CONSTRAINTS));
 

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.SortCommand.MESSAGE_INVALID_SKILL;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -20,6 +21,15 @@ class SortCommandParserTest {
     public void parse_emptyArg_throwsParseException() {
         assertParseFailure(parser, "     ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidSkillName_throwsParseException() {
+        // Multiple skill name
+        assertParseFailure(parser, "C Python", String.format(MESSAGE_INVALID_SKILL, Skill.NAME_CONSTRAINTS));
+
+        // Non-alphanumeric skill name
+        assertParseFailure(parser, "C_90", String.format(MESSAGE_INVALID_SKILL, Skill.NAME_CONSTRAINTS));
     }
 
     @Test


### PR DESCRIPTION
Passing invalid args as skill name to SortCommand resulted in no error message. 
This commit fixes this bug and adds test to check for this behaviour.

Fixes: #56 