### PR TITLE
Enhance 'HelpCommand' to display help messages upon entering a topic

### DIFF
--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.commands;
 
+import java.util.Set;
+
 import seedu.address.model.Model;
+
 
 /**
  * Format full help instructions for every command for display.
@@ -8,14 +11,68 @@ import seedu.address.model.Model;
 public class HelpCommand extends Command {
 
     public static final String COMMAND_WORD = "help";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
-            + "Example: " + COMMAND_WORD;
+    public static final Set<String> AVAILABLE_HELP_TOPICS = Set.of("add", "delete", "find", "filter", "list", "skill",
+            "team", "unteam", "sort", "");
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions. Usage: <Help> "
+            + "to get link to user guide or <Help> <Topic> to get help for particular topic \n"
+            + "Example: " + COMMAND_WORD + "\nExample: " + COMMAND_WORD + " list\n";
 
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
+    public static final String HELP_MESSAGE_ADD = AddCommand.MESSAGE_USAGE;
+    public static final String HELP_MESSAGE_DELETE = DeleteCommand.MESSAGE_USAGE;
+    public static final String HELP_MESSAGE_FIND = FindCommand.MESSAGE_USAGE;
+    public static final String HELP_MESSAGE_FILTER = FilterSkillCommand.MESSAGE_USAGE;
+    public static final String HELP_MESSAGE_LIST = ListCommand.MESSAGE_USAGE;
+    public static final String HELP_MESSAGE_SORT = SortCommand.MESSAGE_USAGE;
+    public static final String HELP_MESSAGE_TEAM = MakeTeamCommand.MESSAGE_USAGE;
+    public static final String HELP_MESSAGE_UNTEAM = MakeTeamCommand.MESSAGE_USAGE;
+    public static final String HELP_MESSAGE_SKILL = "Skill stores a Skill Name and Skill proficiency. Usage: "
+            + "<Command> s/<Skill Name>_<Skill Proficiency> \nExample: edit 1 s/Java_50\n ";
+
+    public final String topic;
+    public HelpCommand(String topic) {
+        this.topic = topic;
+    }
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        switch (topic) {
+        case "add":
+            return new CommandResult(HELP_MESSAGE_ADD, false, false);
+        case "delete":
+            return new CommandResult(HELP_MESSAGE_DELETE, false, false);
+        case "find":
+            return new CommandResult(HELP_MESSAGE_FIND, false, false);
+        case "filter":
+            return new CommandResult(HELP_MESSAGE_FILTER, false, false);
+        case "list":
+            return new CommandResult(HELP_MESSAGE_LIST, false, false);
+        case "skill":
+            return new CommandResult(HELP_MESSAGE_SKILL, false, false);
+        case "team":
+            return new CommandResult(HELP_MESSAGE_TEAM, false, false);
+        case "unteam":
+            return new CommandResult(HELP_MESSAGE_UNTEAM, false, false);
+        case "sort":
+            return new CommandResult(HELP_MESSAGE_SORT, false, false);
+        default:
+            return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        }
     }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+        // instanceof handles nulls
+        if (!(other instanceof HelpCommand)) {
+            return false;
+        }
+        HelpCommand toCompare = (HelpCommand) other;
+        return toCompare.topic.equals(toCompare.topic);
+
+    }
+
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -11,6 +11,7 @@ import seedu.address.model.Model;
 public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
+    public static final String MESSAGE_USAGE = "use list to show all contacts. Usage: <list>";
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -89,7 +89,7 @@ public class AddressBookParser {
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+            return new HelpCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
@@ -1,0 +1,26 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.commands.HelpCommand.AVAILABLE_HELP_TOPICS;
+
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class HelpCommandParser implements Parser<HelpCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the HelpCommand
+     * and returns a HelpCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public HelpCommand parse(String userInput) throws ParseException {
+        String sanitisedUserInput = userInput.toLowerCase().trim();
+        requireAllNonNull(userInput);
+        if (!AVAILABLE_HELP_TOPICS.contains(sanitisedUserInput)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+        return new HelpCommand(sanitisedUserInput);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -15,6 +15,6 @@ public class HelpCommandTest {
     @Test
     public void execute_help_success() {
         CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
-        assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
+        assertCommandSuccess(new HelpCommand(""), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -85,8 +85,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_help() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + "") instanceof HelpCommand);
+        assertThrows(ParseException.class, ()-> parser.parseCommand(HelpCommand.COMMAND_WORD + " 3"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/HelpCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HelpCommandParserTest.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class HelpCommandParserTest {
+
+    private HelpCommandParser parser = new HelpCommandParser();
+
+    @Test
+    public void parse_validArgs() throws ParseException {
+
+        //Exact same input
+        assertEquals(new HelpCommand("add"), parser.parse("add"));
+
+        //Input with spacing
+        assertEquals(new HelpCommand("delete"), parser.parse(" delete "));
+
+        //Input with uppercase characters
+        assertEquals(new HelpCommand("sort"), parser.parse("SoRT"));
+    }
+
+    @Test
+    public void parse_invalidArgs() {
+        assertThrows(ParseException.class, ()-> parser.parse("NotInsideHelp"));
+        assertThrows(ParseException.class, ()-> parser.parse("***"));
+    }
+
+}


### PR DESCRIPTION
`HelpCommand` will give a brief description, usage and examples based on `topic` given. If no `topic` is given, a help window linking to the user guide will appear (no change from previous versions)

 e.g. 
`help add`  will now show  
```
add: Adds a person to HackNet. 

Parameters: n/NAME p/PHONE e/EMAIL g/GITHUB USERNAME [t/TEAM]... [s/SKILLNAME_SKILLPROFICENCY]...

Example: add n/John Doe p/98765432 e/johnd@example.com g/johndoe-123 t/friends t/owesMoneys/Java_90
```