### PR TITLE
Branch add comma separate

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -72,8 +72,8 @@ Welcome to the User Guide for **HackNet**, where we will guide you through all y
 * Items in square brackets are optional.<br>
     * e.g `n/NAME [t/TEAM]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
 
-* Items with `…`​ after them can be used multiple times including zero times.<br>
-    * e.g. `[t/TEAM]…​` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
+* Items with `…`​ after them can have multiple values including 0, separated by a comma.<br>
+    * e.g. `[t/TEAM…]​` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend, family` etc.
 
 * Parameters can be in any order.<br>
     * e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
@@ -112,15 +112,15 @@ This section contains commands that can help you manage the details of your cont
 
 Adds a person to HackNet.
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL g/GITHUB_USERNAME [t/TEAM]…​ [s/SKILLNAME_SKILLPROFICENCY]…​`
+Format: `add n/NAME p/PHONE_NUMBER e/EMAIL g/GITHUB_USERNAME [t/TEAM…]​ [s/SKILLNAME_SKILLPROFICENCY…]​`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
-A person can have any number of teams (including 0)
+A person can have any number of teams or skills(including 0)
 </div>
 
 Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com g/johndoe123`
-* `add n/Betsy Crowe t/friend e/betsycrowe@example.com g/betsycoder p/1234567 t/entrepeneur s/java_80`
+* `add n/Betsy Crowe e/betsycrowe@example.com g/betsycoder p/1234567 t/entrepeneur, friend  s/java_80`
 
 ### Editing a person: `edit`
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -25,33 +25,7 @@ import seedu.address.model.team.Team;
  * Parses input arguments and creates a new AddCommand object
  */
 public class AddCommandParser implements Parser<AddCommand> {
-
-    /**
-     * Parses the given {@code String} of arguments in the context of the AddCommand
-     * and returns an AddCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
-     */
-    public AddCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_GITHUB_USERNAME,
-                    PREFIX_TEAM, PREFIX_SKILL);
-
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_GITHUB_USERNAME, PREFIX_PHONE, PREFIX_EMAIL)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-        }
-
-        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        GithubUsername username = ParserUtil.parseGithubUsername(argMultimap.getValue(PREFIX_GITHUB_USERNAME).get());
-        Set<Team> teamList = ParserUtil.parseTeams(argMultimap.getAllValues(PREFIX_TEAM));
-        SkillSet skillSet = ParserUtil.parseSkillSet(argMultimap.getAllValues(PREFIX_SKILL));
-
-        Person person = new Person(name, phone, email, username, teamList, skillSet, false);
-
-        return new AddCommand(person);
-    }
+    private final String separator = "\\s?,\\s?";
 
     /**
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given
@@ -59,6 +33,35 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand
+     * and returns an AddCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+            ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_GITHUB_USERNAME,
+                PREFIX_TEAM, PREFIX_SKILL);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_GITHUB_USERNAME, PREFIX_PHONE, PREFIX_EMAIL)
+            || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        }
+
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+        GithubUsername username = ParserUtil.parseGithubUsername(argMultimap.getValue(PREFIX_GITHUB_USERNAME).get());
+        Set<Team> teamList = ParserUtil.parseTeamsWithRegex(argMultimap.getValue(PREFIX_TEAM), separator);
+        SkillSet skillSet =
+            new SkillSet(ParserUtil.parseSkillsWithRegex(argMultimap.getValue(PREFIX_SKILL), separator));
+
+        Person person = new Person(name, phone, email, username, teamList, skillSet, false);
+
+        return new AddCommand(person);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -136,7 +136,7 @@ public class ParserUtil {
 
     /**
      * Parses a {@code String skill} into a {@code skill}.'
-     *
+     * <p>
      * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code skill} is invalid.
@@ -172,6 +172,57 @@ public class ParserUtil {
             teamSet.add(parseTeam(teamName));
         }
         return teamSet;
+    }
+
+
+    /**
+     * Converts userInput of team arguments to {@code Set} of {@code Team}s.
+     *
+     * @param optionalTeamNames The userInput provided. Is empty if the user did not provide any team argument.
+     * @param separator         The Regex used to parse multiple teamNames.
+     * @return Set of teams.
+     * @throws ParseException If a teamName cannot be parsed.
+     */
+    public static Set<Team> parseTeamsWithRegex(Optional<String> optionalTeamNames, String separator)
+        throws ParseException {
+        Set<Team> teamSet = new HashSet<>();
+        if (!optionalTeamNames.isPresent()) {
+            return teamSet;
+        }
+        String teamNames = optionalTeamNames.get();
+        String[] separatedTeamNames = teamNames.split(separator, 0);
+        if (!(separatedTeamNames.length == 1 && separatedTeamNames[0].equals(""))) {
+            for (String teamName : separatedTeamNames) {
+                Team team = ParserUtil.parseTeam(teamName);
+                teamSet.add(team);
+            }
+        }
+        return teamSet;
+    }
+
+    /**
+     * Converts userInput of skills to {@code Set} of {@code Skill}s
+     *
+     * @param optionalSkillNamesWithLvl UserInput of the skills.
+     * @param separator Regex to split the userInput and identify each skill.
+     * @return The {@code Set} of {@code Skill} identified from UserInput.
+     * @throws ParseException If the skill with level specified cannot be parsed.
+     */
+    public static Set<Skill> parseSkillsWithRegex(Optional<String> optionalSkillNamesWithLvl, String separator)
+        throws ParseException {
+        Set<Skill> skillSet = new HashSet<>();
+        if (!optionalSkillNamesWithLvl.isPresent()) {
+            return skillSet;
+        }
+        String skillNamesWithLvl = optionalSkillNamesWithLvl.get();
+        String[] separatedSkillNameWithLvl = skillNamesWithLvl.split(separator, 0);
+        if (!(separatedSkillNameWithLvl.length == 1 && separatedSkillNameWithLvl[0].equals(""))) {
+            for (String skillNameWithLvl : separatedSkillNameWithLvl) {
+                Skill skill = ParserUtil.parseSkill(skillNameWithLvl);
+                skillSet.add(skill);
+            }
+        }
+        return skillSet;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -24,7 +24,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TEAM_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TEAM_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_USERNAME_BOB;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -44,6 +43,7 @@ import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandParserTest {
     private AddCommandParser parser = new AddCommandParser();
+    private String separator = ",";
 
     @Test
     public void parse_allFieldsPresent_success() {
@@ -69,11 +69,11 @@ public class AddCommandParserTest {
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + USERNAME_DESC_AMY
             + USERNAME_DESC_BOB + TEAM_DESC_FRIEND + SKILL_DESC_PYTHON, new AddCommand(expectedPerson));
 
-        // multiple teams - all accepted
-        Person expectedPersonMultipleTeams = new PersonBuilder(BOB).withTeams(VALID_TEAM_FRIEND, VALID_TEAM_HUSBAND)
+        // multiple teams - last team accepted
+        Person expectedPersonSingleTeam = new PersonBuilder(BOB).withTeams(VALID_TEAM_FRIEND)
             .build();
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + USERNAME_DESC_BOB
-            + TEAM_DESC_HUSBAND + TEAM_DESC_FRIEND + SKILL_DESC_PYTHON, new AddCommand(expectedPersonMultipleTeams));
+            + TEAM_DESC_HUSBAND + TEAM_DESC_FRIEND + SKILL_DESC_PYTHON, new AddCommand(expectedPersonSingleTeam));
     }
 
     @Test


### PR DESCRIPTION
Argument syntax for `add` has changed to be similar with `edit` and `batchedit`.

The arguments for teams and skills should be comma separated for the arguments to be parsed.
`Add n/Junha p/12345678 g/B1P4R e/bd0800@gmail.com t/hello, world s/python_100, java_10` adds a person named Junha in HackNet, with the team `hello`, `world`, and with the skill `pthon` and `java`.

Only the values after the last prefix will be accepted if there multple prefixes provided for teams and skills.
`Add n/Junha p/12345678 g/B1P4R e/bd0800@gmail.com t/hello, world t/bye, world` adds a person named Junha in HackNet, with the team `bye`, `world`.