### PR TITLE
Inform users of detection of partially invalid indices for edit command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -133,7 +133,8 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL g/GITHUB_USERNAME [t/TEAM…]​ [s/S
 
 * A person can have any number of teams or skills(including 0)
 * teams and skills in `[t/TEAM…]` and `[s/SKILLNAME_SKILLPROFICENCY…]` must be separated by a comma. The comma can be preceded or followed by any number of whitespaces, which will be ignored. Any excess commas after the last valid value will be ignored.
-* `t/      ` and `s/        ` is treated as `t/` and `s/` as HackNet ignores whitespaces. Therefore, a name of a team cannot be consisting solely of whitespaces.
+* Consecutive white spaces right after `t/` and `s/` are ignored.
+* A name of a team or skill cannot be consisting solely of whitespaces.
 </div>
 
 Examples:
@@ -149,14 +150,16 @@ Format: `edit INDEX [INDEX…] [-r] [n/NAME] [p/PHONE] [e/EMAIL] [g/GITHUB_USERN
 * Edits the person(s) at the specified `INDEX [INDEX…]`. The index refers to the index number shown in the displayed person list. Indices must be separated by a whitespace as opposed to teams and skills. All index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided besides `[-r]`.
 * team and skill values in `[t/TEAM…]` and `[s/SKILLNAME_SKILLPROFICENCY…]` must be separated by a comma. The comma can be preceded or followed by any number of whitespaces, which will be ignored. Any excess commas after the last valid value will be ignored.
-* `t/      ` and `s/        ` is treated as `t/` and `s/` as HackNet ignores whitespaces. Therefore, a name of a team cannot be consisting solely of whitespaces.
+* Consecutive white spaces right after `t/` and `s/` are ignored.
+* A name of a team or skill cannot be consisting solely of whitespaces.
 * Existing values will be updated to the input values.
 * In default mode, editing teams appends the new team to the person.
 * `-r` option activates reset mode.
 * In reset mode, editing teams edits the teams of a person from scratch. i.e adding of teams is not cumulative. You can remove all the person’s teams by typing `t/` without
   specifying any teams after it.
 * The concept of default and reset mode applies with skills as well.
-* when editing multiple persons, only `[t/TEAM…]` and `[s/SKILLNAME_SKILLPROFICENCY…]` will take effect. Other arguments such as `Name` and `Phone` will be silently ignored.
+* When editing multiple persons, only `[t/TEAM…]` and `[s/SKILLNAME_SKILLPROFICENCY…]` will take effect. Other arguments such as `NAME` and `PHONE` will be silently ignored.
+* When at least one of the indices provided are invalid for batch edit, HackNet informs that there was an error in the indices, but still delivers the modification for the indices that are valid.
 
 Examples:
 * `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -160,6 +160,7 @@ Format: `edit INDEX [INDEX…] [-r] [n/NAME] [p/PHONE] [e/EMAIL] [g/GITHUB_USERN
 * The concept of default and reset mode applies with skills as well.
 * When editing multiple persons, only `[t/TEAM…]` and `[s/SKILLNAME_SKILLPROFICENCY…]` will take effect. Other arguments such as `NAME` and `PHONE` will be silently ignored.
 * When at least one of the indices provided are invalid for batch edit, HackNet informs that there was an error in the indices, but still delivers the modification for the indices that are valid.
+* In the unlikely case that same index is present multiple times for `INDEX [INDEX…]`, HackNet will still successfully execute the edit command as long as the index is valid.
 
 Examples:
 * `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -230,7 +230,6 @@ public class EditCommand extends Command {
         model.updateDisplayPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         // Throwing error after editing for valid indices allows the successful edit for least the valid indices.
-        String executionStatus;
         if (!isAllIndicesValid) {
             return new CommandResult(
                 String.format(

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -36,12 +36,15 @@ public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
     public static final String RESET_ARG = "r";
+    public static final String MESSAGE_USAGE_OPTIONS =
+        "The symbol '-' is used to declare options for edit command, and can be declared only once in the command.\n"
+            + "The only available option is 'r', which makes the edit command execute in reset mode.";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person(s) identified "
         + "by the index number(s) used in the displayed person list.\n"
         + "Existing values will be overwritten by the input values.\n"
         + "Index numbers should be separated by a white space,"
-        + "as opposed to other teams and skill values that are separated by a comma."
+        + "as opposed to other teams and skill values that should be separated by a comma."
         + "\n"
         + "By default, Teams will be appended.\n"
         + "However in reset mode, editing Teams will purge all previous data.\n"
@@ -227,8 +230,14 @@ public class EditCommand extends Command {
         model.updateDisplayPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         // Throwing error after editing for valid indices allows the successful edit for least the valid indices.
+        String executionStatus;
         if (!isAllIndicesValid) {
-            throw new CommandException(Messages.MESSAGE_INVALID_INDEX_FOR_SOME_PERSON);
+            return new CommandResult(
+                String.format(
+                    Messages.MESSAGE_INVALID_INDEX_FOR_SOME_PERSON
+                        + "\n"
+                        + MESSAGE_EDIT_MULTIPLE_PERSON_SUCCESS,
+                    editedNames));
         }
         return new CommandResult(String.format(MESSAGE_EDIT_MULTIPLE_PERSON_SUCCESS, editedNames));
     }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -63,7 +63,18 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         boolean isResetMode = false;
         if (argMultimap.getValue(PREFIX_COMMAND_OPTION).isPresent()) {
+            int optionDeclarationNumber = argMultimap.getAllValues(PREFIX_COMMAND_OPTION).size();
+            // if there are multiple '-' present
+            if (optionDeclarationNumber != 1) {
+                throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE_OPTIONS));
+            }
             String option = argMultimap.getValue(PREFIX_COMMAND_OPTION).get();
+            // if there there is any other option declared other than the one and only currently supported option, 'r'
+            if (!option.equals(EditCommand.RESET_ARG)) {
+                throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE_OPTIONS));
+            }
             isResetMode = option.equals(EditCommand.RESET_ARG);
         }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -54,7 +54,11 @@ public class ParserUtil {
         LinkedList<Index> indices = new LinkedList<>();
         for (String number : numbers) {
             number = number.trim();
-            indices.add(parseIndex(number));
+            Index indexToAdd = parseIndex(number);
+            if (indices.contains(indexToAdd)) {
+                continue;
+            }
+            indices.add(indexToAdd);
         }
         return indices;
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -55,6 +55,7 @@ public class ParserUtil {
         for (String number : numbers) {
             number = number.trim();
             Index indexToAdd = parseIndex(number);
+            // ignore duplicate indexes
             if (indices.contains(indexToAdd)) {
                 continue;
             }


### PR DESCRIPTION
Partially invalid indices for batch edit using edit command does not
inform user of the detection. Instead, it only results in execution of
modification for at least the valid indices as an attempt to try best
to edit the persons.

Not informing users of the partial failure results in user being unaware
of the incomplete status of the edit command. This negatively affects
the user's workflow.