### PR TITLE
Bugfix for length of email, skill and team.

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -84,7 +84,7 @@ This could be a problem with the Windows OS. You can alternatively start **HackN
     * e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
 
 * Items in square brackets are optional.<br>
-    * e.g `n/NAME [t/TEAM]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
+    * e.g. `n/NAME [t/TEAM]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
 
 * Items with `…`​ after them can have multiple values including 0.<br>
     * e.g. `[t/TEAM…]​` can be used as ` ` (i.e. 0 times), `t/`, `t/friend, family` etc.
@@ -98,7 +98,9 @@ This could be a problem with the Windows OS. You can alternatively start **HackN
 * Extraneous parameters for commands that do not take in parameters (such as `list`, `undo`, `redo`, `exit` and `clear`) will be ignored.<br>
     * e.g. if the command specifies `list 123`, it will be interpreted as `list`.
 
-* For skill field, Skill name have to be followed by a underscore `_` and Skill proficiency level that ranges from 0 to 100 with 0 being the lowest proficiency level.
+* For the team field, maximum length of a team name is 20 characters.
+
+* For skill field, Skill name have to be followed by an underscore `_` and Skill proficiency level that ranges from 0 to 100 with 0 being the lowest proficiency level. Maximum length of a skill name is 10 characters.
     * e.g. `[s/SKILLNAME_SKILLPROFICENCY…]​` as `s/Java_90`
 
 
@@ -129,18 +131,18 @@ Adds a person to HackNet.
 
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL g/GITHUB_USERNAME [t/TEAM…]​ [s/SKILLNAME_SKILLPROFICENCY…]​`
 
-<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+<div markdown="block" class="alert alert-info">
 
-* A person can have any number of teams or skills(including 0)
-* teams and skills in `[t/TEAM…]` and `[s/SKILLNAME_SKILLPROFICENCY…]` must be separated by a comma. The comma can be preceded or followed by any number of whitespaces, which will be ignored. Any excess commas after the last valid value will be ignored.
-* `t/      ` and `s/        ` is treated as `t/` and `s/` as HackNet ignores whitespaces. Therefore, a name of a team cannot be consisting solely of whitespaces.
-* HackNet can store multiple contacts with the same `Name` but will reject inputs that contain any `Email`, `Github Username` or `Phone Number` fields that already exists in HackNet.
-* Consecutive white spaces right after `t/` and `s/` are ignored.
-* A name of a team or skill cannot be consisting solely of whitespaces.
-* Please check that you have correctly entered the skill proficiency level.
-There is currently no way of viewing the exact number that you entered.
-You may use the `edit` function to change it if it is wrong.
-* The skill proficiency will only be a visual guide in a shade of green (bright green for high proficiency and dark green for low proficiency).
+**:information_source: Notes regarding adding a person:**<br>
+
+* A person can have any number of teams or skills(including 0)<br>
+* teams and skills in `[t/TEAM…]` and `[s/SKILLNAME_SKILLPROFICENCY…]` must be separated by a comma. The comma can be preceded or followed by any number of whitespaces, which will be ignored. Any excess commas after the last valid value will be ignored.<br>
+* `t/      ` and `s/        ` is treated as `t/` and `s/` as HackNet ignores whitespaces. Therefore, a name of a team cannot be consisting solely of whitespaces.<br>
+* HackNet can store multiple contacts with the same `Name` but will reject inputs that contain any `Email`, `Github Username` or `Phone Number` fields that already exists in HackNet.<br>
+* Consecutive white spaces right after `t/` and `s/` are ignored.<br>
+* A name of a team or skill cannot be consisting solely of whitespaces.<br>
+* Please check that you have correctly entered the skill proficiency level. There is currently no way of viewing the exact number that you entered. You may use the `edit` function to change it if it is wrong. <br>
+* The skill proficiency will only be a visual guide in a shade of green (bright green for high proficiency and dark green for low proficiency).<br>
 </div>
 
 Examples:

--- a/docs/team/tzhan98.md
+++ b/docs/team/tzhan98.md
@@ -31,6 +31,7 @@ Given below are my contributions to the project.
   * Add more topics that `help` is able to search for such as `filterteam` [#107](https://github.com/AY2122S2-CS2103T-W13-3/tp/issues/107)
   * Add input validation for `Github username` such that it complies with actual Github username rules [#147](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/147)
   * Change HackNet to allow for duplicate `name` fields but reject any command that try to add/edit a duplicate or existing `Github username`, `phone number` or `email` [#154](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/154)
+  * Add length checks for `email`, `team` and `skill` [#167](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/167)
 
 * **Documentation**:
   * User Guide:

--- a/docs/team/tzhan98.md
+++ b/docs/team/tzhan98.md
@@ -37,8 +37,12 @@ Given below are my contributions to the project.
     * Add documentation for [Help feature](https://github.com/AY2122S2-CS2103T-W13-3/tp/blob/master/docs/UserGuide.md#viewing-help-help)
     * Add documentation for [Skills feature](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/39/files)
     * [Fix UG errors](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/140)
+    * [Update UG and Add Q&A](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/164)
+
   * Developer Guide:
     * [Update DG to include sequence diagrams and class diagrams of skills](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/59)
+    * [Add use cases, NFR and glossary](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/164)
+
 
 * **Community**:
-  * PR reviewed [#62](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/62), [#73](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/73), [#79](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/79), [#141](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/141)
+  * PR reviewed with non-trivial comments [#62](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/62), [#73](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/73), [#79](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/79), [#141](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/141)

--- a/docs/team/tzhan98.md
+++ b/docs/team/tzhan98.md
@@ -14,6 +14,10 @@ Given below are my contributions to the project.
   * _Justification_: This feature is one of the unique selling point of HackNet and most of the other functions build on top of this feature. It allows the user to keep track of the expertise of individuals.
   * _Highlights_: This enhancement affects existing commands and commands to be added in the future. It required an in-depth analysis of design alternatives. The implementation too was challenging as it required changes to existing commands. To improve abstraction, I had to implement the class `SkillSet` to store multiple `Skill`s and a `JsonAdaptedSkill` to store the information in Json format.
 
+* **New Feature**: Skill to display as different colors to indicate proficiency
+  * _What it does_: differentiate different level of skill proficiency with different hues of green with brighter green indicating a higher level of proficiency
+  * _Justification_: How everyone perceives their own skill proficiency is only a rough gauge, and they may have different standards of judging their skill levels. Therefore, the numbers may not accurately reflect in real life. To reduce bias, we have decided on using a range of colors to indicate proficiency instead.
+
 * **Code contributed**: [RepoSense link](https://nus-cs2103-ay2122s2.github.io/tp-dashboard/?search=tzhan98&sort=groupTitle&sortWithin=title&timeframe=commit&mergegroup=&groupSelect=groupByRepos&breakdown=true&checkedFileTypes=docs~functional-code~test-code~other&since=2022-02-18&tabOpen=true&tabType=authorship&tabAuthor=tzhan98&tabRepo=AY2122S2-CS2103T-W13-3%2Ftp%5Bmaster%5D&authorshipIsMergeGroup=false&authorshipFileTypes=&authorshipIsBinaryFileTypeChecked=false)
 
 * **Project management**:
@@ -23,7 +27,7 @@ Given below are my contributions to the project.
 
 * **Enhancements to existing features**:
   * Enhanced `Help` Command to search for a topic to get help in.
-  * Enhanced `Skill` to display different hues of green to indicate how proficient the user is.
+    * This allows for users to easily check for information of commands without constantly referring to the user guide
 
 * **Bug fixes**:
   * Fix input validation of regex to exclude values from `Skill proficiency` [#136](https://github.com/AY2122S2-CS2103T-W13-3/tp/issues/136)

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import java.util.Set;
 
 import seedu.address.model.Model;
+import seedu.address.model.team.Skill;
 
 
 /**
@@ -33,8 +34,7 @@ public class HelpCommand extends Command {
     public static final String HELP_MESSAGE_UNDO = UndoCommand.MESSAGE_USAGE;
     public static final String HELP_MESSAGE_SHOW = ShowCommand.MESSAGE_USAGE;
     public static final String HELP_MESSAGE_FILTERTEAM = FilterPastTeamCommand.MESSAGE_USAGE;
-    public static final String HELP_MESSAGE_SKILL = "Skill stores a Skill Name and Skill proficiency. Usage: "
-            + "<Command> s/<Skill Name>_<Skill Proficiency> \nExample: edit 1 s/Java_50\n ";
+    public static final String HELP_MESSAGE_SKILL = Skill.MESSAGE_USAGE;
 
     public final String topic;
     public HelpCommand(String topic) {

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -55,6 +55,9 @@ public class Email {
         return test.matches(VALIDATION_REGEX) && isValidLength(test);
     }
 
+    /**
+     * Returns if given string has a valid email length.
+     */
     public static boolean isValidLength(String test) {
         int len = test.length();
         return len >= MIN_LENGTH_OF_EMAIL && len <= MAX_LENGTH_OF_EMAIL;

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -9,6 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Email {
 
+    private static final int MAX_LENGTH_OF_EMAIL = 150;
+    private static final int MIN_LENGTH_OF_EMAIL = 4;
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
@@ -20,7 +22,9 @@ public class Email {
             + "The domain name must:\n"
             + "    - end with a domain label at least 2 characters long\n"
             + "    - have each domain label start and end with alphanumeric characters\n"
-            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
+            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.\n"
+            + "3. The total length of email should have between " + MIN_LENGTH_OF_EMAIL + " to " + MAX_LENGTH_OF_EMAIL
+            + " characters. (inclusive)\n";
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
     private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
@@ -48,7 +52,12 @@ public class Email {
      * Returns if a given string is a valid email.
      */
     public static boolean isValidEmail(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && isValidLength(test);
+    }
+
+    public static boolean isValidLength(String test) {
+        int len = test.length();
+        return len >= MIN_LENGTH_OF_EMAIL && len <= MAX_LENGTH_OF_EMAIL;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/team/Skill.java
+++ b/src/main/java/seedu/address/model/team/Skill.java
@@ -13,10 +13,11 @@ import java.util.logging.Logger;
  */
 public class Skill {
 
-
+    public static final int MAX_LENGTH_OF_SKILL_NAME = 10;
     public static final String NAME_CONSTRAINTS =
-        "Skill names should be alphanumeric word(s) that can contain special characters #, +, and -";
-    //The regex below checks for skill name constraints dexcribed in NAME_CONSTRAINTS above.
+        "Skill names should be alphanumeric word(s) that can contain special characters #, +, and -. \nMaximum length "
+                + "of a skill name is 10 characters.";
+    //The regex below checks for skill name constraints described in NAME_CONSTRAINTS above.
     public static final String NAME_VALIDATION_REGEX = "[\\w|\\d|\\s#+-]+";
     public static final String PROFICIENCY_CONSTRAINTS_RANGE = "Skill proficiency should be within range of 1-100";
     public static final String PROFICIENCY_CONSTRAINTS_INTEGER = "Skill proficiency must be an integer";
@@ -24,6 +25,10 @@ public class Skill {
     public static final String PROFICIENCY_VALIDATION_ONLY_INTEGERS = "^[0-9]+$";
     public static final String SKILL_INPUT_CONSTRAINTS = "Skill input should be: Skill Name_Skill proficiency. eg: "
         + "Java_50";
+    public static final String MESSAGE_USAGE = "Skill stores a Skill Name and Skill proficiency."
+            + "Skill proficiency is indicated by different hues of green with brighter "
+            + "green indicating a higher proficiency.\n"
+            + "Usage: <Command> s/<Skill Name>_<Skill Proficiency> \nExample: edit 1 s/Java_50\n";
     private static Logger logger = Logger.getLogger("Skill");
 
     public final String skillName;
@@ -42,8 +47,8 @@ public class Skill {
         checkArgument(isValidSkillProficiencyRange(skillProficiency), PROFICIENCY_CONSTRAINTS_RANGE);
         this.skillName = skillName;
         this.skillProficiency = skillProficiency;
-        assert skillProficiency <= 100 && skillProficiency > 0 : "Skill proficiency is between 1 to 100";
-        assert skillName != null : "Skill name is not null";
+        assert skillProficiency <= 100 && skillProficiency > 0 : "Skill proficiency should be between 1 to 100";
+        assert skillName != "" : "Skill name should not be empty";
         logger.log(Level.INFO, String.format("Created %s with proficiency of %d", skillName, skillProficiency));
     }
 
@@ -57,7 +62,7 @@ public class Skill {
         checkArgument(isValidSkillName(skillName), NAME_CONSTRAINTS);
         this.skillName = skillName;
         this.skillProficiency = 1;
-        assert skillName != null : "Skill name is not null";
+        assert skillName != "" : "Skill name should not be empty";
         logger.log(Level.INFO, String.format("Created %s with proficiency of 0", skillName));
     }
 
@@ -65,7 +70,7 @@ public class Skill {
      * Returns true if a given string is a valid skill name.
      */
     public static boolean isValidSkillName(String test) {
-        return test.matches(NAME_VALIDATION_REGEX);
+        return test.matches(NAME_VALIDATION_REGEX) && test.length() <= MAX_LENGTH_OF_SKILL_NAME;
     }
 
     /**

--- a/src/main/java/seedu/address/model/team/Team.java
+++ b/src/main/java/seedu/address/model/team/Team.java
@@ -9,7 +9,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Team {
 
-    public static final String MESSAGE_CONSTRAINTS = "teams names should be alphanumeric word(s)";
+    public static final int MAX_LENGTH_OF_TEAM_NAME = 20;
+    public static final String MESSAGE_CONSTRAINTS = "Team names should be alphanumeric word(s) and may"
+            + " contain spaces.\n Maximum length of a Team name is 20 characters.";
     // The REGEX below is the regex that checks for the team name constraint mentioned on MESSAGE_CONSTRAINTS
     public static final String VALIDATION_REGEX = "[\\d|\\w|\\s]+";
 
@@ -30,7 +32,7 @@ public class Team {
      * Returns true if a given string is a valid team name.
      */
     public static boolean isValidTeamName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && test.length() <= MAX_LENGTH_OF_TEAM_NAME;
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -44,7 +44,7 @@ public class CommandTestUtil {
     public static final String VALID_TEAM_HACKING_TEAM = "hacking team";
     public static final String VALID_SKILL_C = "C_33";
     public static final String VALID_SKILL_PYTHON = "python_90";
-    public static final String VALID_SKILL_UNIT_TESTING = "unit testing_90";
+    public static final String VALID_SKILL_UNIT_TESTING = "unit test_90";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -21,6 +22,12 @@ public class EmailTest {
 
     @Test
     public void isValidEmail() {
+        //email with 150 characters.
+        String longEmail = "Tom-Alex_Doe_lee_Dr_steven_yeoh_Amos1234PeterJack_1190PeterJack_1190"
+                + "PeterJack_1190PeterJack_1190PeterJack_1190PeterJack_1190PeterJack_1190@example.com";
+
+        assertEquals(150, longEmail.length());
+
         // null email
         assertThrows(NullPointerException.class, () -> Email.isValidEmail(null));
 
@@ -51,6 +58,8 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
+        assertFalse(Email.isValidEmail("a")); // lesser than min number of characters
+        assertFalse(Email.isValidEmail(longEmail + "a")); //151 characters (more than max number of characters)
 
         // valid email
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
@@ -64,5 +73,7 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
+        assertTrue(Email.isValidEmail(longEmail)); //150 characters (max number of characters)
+
     }
 }

--- a/src/test/java/seedu/address/model/team/SkillTest.java
+++ b/src/test/java/seedu/address/model/team/SkillTest.java
@@ -69,6 +69,33 @@ public class SkillTest {
     public void isValidSkillName() {
         // null skill argument
         assertThrows(NullPointerException.class, () -> Skill.isValidSkillName(null));
+
+        //valid skill name
+        assertTrue(Skill.isValidSkillName("Java"));
+
+        //valid skill name (10 characters)
+        assertTrue(Skill.isValidSkillName("MakingSome"));
+
+        //valid special character: +
+        assertTrue(Skill.isValidSkillName("C++"));
+
+        //valid special character: #
+        assertTrue(Skill.isValidSkillName("C#"));
+
+        //valid special character: -
+        assertTrue(Skill.isValidSkillName("Sky-diving"));
+
+        //invalid special character: $
+        assertFalse(Skill.isValidSkillName("making$"));
+
+        //invalid special character: space
+        assertFalse(Skill.isValidSkillName("making some money"));
+
+        //no name provided
+        assertFalse(Skill.isValidSkillName(""));
+
+        //skill name longer than 10 characters (11 characters)
+        assertFalse(Skill.isValidSkillName("MakingSomeM"));
     }
 
     @Test void isValidSkillProficiency() {

--- a/src/test/java/seedu/address/model/team/TeamTest.java
+++ b/src/test/java/seedu/address/model/team/TeamTest.java
@@ -1,7 +1,9 @@
 package seedu.address.model.team;
 
+
 import static seedu.address.testutil.Assert.assertThrows;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TeamTest {
@@ -21,6 +23,18 @@ public class TeamTest {
     public void isValidTeamName() {
         // null team name
         assertThrows(NullPointerException.class, () -> Team.isValidTeamName(null));
+
+        //team name with special characters
+        Assertions.assertFalse(Team.isValidTeamName("Math tE@M"));
+
+        //team name of 20 characters
+        Assertions.assertTrue(Team.isValidTeamName("Math Olympiad team 1"));
+
+        //empty team name
+        Assertions.assertFalse(Team.isValidTeamName(""));
+
+        //team name greater than 20 characters (21 characters)
+        Assertions.assertFalse(Team.isValidTeamName("Math Olympiad team 15"));
     }
 
 }


### PR DESCRIPTION
Added checks for email, team and skill length.

- email length should be between 3 to 150 characters (inclusive)
- team will have a max length of 20 characters
- skill will have a max length of 10 characters