### PR TITLE
Fix `NumberFormatException` on parsing large skill proficiency

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -155,13 +155,23 @@ public class ParserUtil {
         if (!Skill.isValidSkillProficiencyInteger(trimmedSkill[1])) {
             throw new ParseException(Skill.PROFICIENCY_CONSTRAINTS_INTEGER);
         }
-        int skillProficiency = Integer.parseInt(trimmedSkill[1]);
-        if (!Skill.isValidSkillName(trimmedSkillName)) {
-            throw new ParseException(Skill.NAME_CONSTRAINTS);
-        }
-        if (!Skill.isValidSkillProficiencyRange(skillProficiency)) {
+
+        int skillProficiency;
+
+        try {
+            skillProficiency = Integer.parseInt(trimmedSkill[1]);
+
+            if (!Skill.isValidSkillName(trimmedSkillName)) {
+                throw new ParseException(Skill.NAME_CONSTRAINTS);
+            }
+            if (!Skill.isValidSkillProficiencyRange(skillProficiency)) {
+                throw new ParseException(Skill.PROFICIENCY_CONSTRAINTS_RANGE);
+            }
+
+        } catch (NumberFormatException e) {
             throw new ParseException(Skill.PROFICIENCY_CONSTRAINTS_RANGE);
         }
+
         return new Skill(trimmedSkillName, skillProficiency);
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -156,19 +156,17 @@ public class ParserUtil {
             throw new ParseException(Skill.PROFICIENCY_CONSTRAINTS_INTEGER);
         }
 
-        int skillProficiency;
+        if (!StringUtil.isNonZeroUnsignedInteger(trimmedSkill[1])) {
+            throw new ParseException(Skill.PROFICIENCY_CONSTRAINTS_INTEGER);
+        }
 
-        try {
-            skillProficiency = Integer.parseInt(trimmedSkill[1]);
+        int skillProficiency = Integer.parseInt(trimmedSkill[1]);
 
-            if (!Skill.isValidSkillName(trimmedSkillName)) {
-                throw new ParseException(Skill.NAME_CONSTRAINTS);
-            }
-            if (!Skill.isValidSkillProficiencyRange(skillProficiency)) {
-                throw new ParseException(Skill.PROFICIENCY_CONSTRAINTS_RANGE);
-            }
+        if (!Skill.isValidSkillName(trimmedSkillName)) {
+            throw new ParseException(Skill.NAME_CONSTRAINTS);
+        }
 
-        } catch (NumberFormatException e) {
+        if (!Skill.isValidSkillProficiencyRange(skillProficiency)) {
             throw new ParseException(Skill.PROFICIENCY_CONSTRAINTS_RANGE);
         }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -204,7 +204,8 @@ public class ParserUtilTest {
     @Test
     public void parseSkill_throwsParseException() throws Exception {
         String invalidProficiencyRange = VALID_SKILL + VALID_SKILL_PREFIX + INVALID_SKILL_PROFICIENCY_RANGE;
-        String invalidProficiencyRangeOverflow = VALID_SKILL + VALID_SKILL_PREFIX + INVALID_SKILL_PROFICIENCY_RANGE_OVERFLOW;
+        String invalidProficiencyRangeOverflow =
+                VALID_SKILL + VALID_SKILL_PREFIX + INVALID_SKILL_PROFICIENCY_RANGE_OVERFLOW;
         String invalidProficiencyType = VALID_SKILL + VALID_SKILL_PREFIX + INVALID_SKILL_PROFICIENCY_TYPE;
         String invalidSkillInput1 = VALID_SKILL + VALID_SKILL_PREFIX + VALID_SKILL_PROFICIENCY
                 + VALID_SKILL_PREFIX + VALID_SKILL;
@@ -217,6 +218,5 @@ public class ParserUtilTest {
         assertThrows(ParseException.class, ()-> ParserUtil.parseSkill(invalidSkillInput1));
         assertThrows(ParseException.class, ()-> ParserUtil.parseSkill(invalidSkillInput2));
         assertThrows(ParseException.class, ()-> ParserUtil.parseSkill(invalidSkillInput3));
-
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -28,6 +28,7 @@ public class ParserUtilTest {
     private static final String INVALID_TEAM = "#friend";
     private static final String INVALID_SKILL_PROFICIENCY_TYPE = "good";
     private static final String INVALID_SKILL_PROFICIENCY_RANGE = "500";
+    private static final String INVALID_SKILL_PROFICIENCY_RANGE_OVERFLOW = "999999999999999999999999999999999999999999";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -203,6 +204,7 @@ public class ParserUtilTest {
     @Test
     public void parseSkill_throwsParseException() throws Exception {
         String invalidProficiencyRange = VALID_SKILL + VALID_SKILL_PREFIX + INVALID_SKILL_PROFICIENCY_RANGE;
+        String invalidProficiencyRangeOverflow = VALID_SKILL + VALID_SKILL_PREFIX + INVALID_SKILL_PROFICIENCY_RANGE_OVERFLOW;
         String invalidProficiencyType = VALID_SKILL + VALID_SKILL_PREFIX + INVALID_SKILL_PROFICIENCY_TYPE;
         String invalidSkillInput1 = VALID_SKILL + VALID_SKILL_PREFIX + VALID_SKILL_PROFICIENCY
                 + VALID_SKILL_PREFIX + VALID_SKILL;
@@ -210,9 +212,11 @@ public class ParserUtilTest {
         String invalidSkillInput3 = VALID_SKILL;
 
         assertThrows(ParseException.class, ()-> ParserUtil.parseSkill(invalidProficiencyRange));
+        assertThrows(ParseException.class, ()-> ParserUtil.parseSkill(invalidProficiencyRangeOverflow));
         assertThrows(ParseException.class, ()-> ParserUtil.parseSkill(invalidProficiencyType));
         assertThrows(ParseException.class, ()-> ParserUtil.parseSkill(invalidSkillInput1));
         assertThrows(ParseException.class, ()-> ParserUtil.parseSkill(invalidSkillInput2));
         assertThrows(ParseException.class, ()-> ParserUtil.parseSkill(invalidSkillInput3));
+
     }
 }


### PR DESCRIPTION
When a very large number is given as the skill proficiency, the parser would throw a `NumberFormatException` and the command will fail silently. 

Fix #176 