### PR TITLE
fix duplicate `skills` during input of multiple skill entries

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -143,11 +143,13 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL g/GITHUB_USERNAME [t/TEAM…]​ [s/S
 * A name of a team or skill cannot be consisting solely of whitespaces.<br>
 * Please check that you have correctly entered the skill proficiency level. There is currently no way of viewing the exact number that you entered. You may use the `edit` function to change it if it is wrong. <br>
 * The skill proficiency will only be a visual guide in a shade of green (bright green for high proficiency and dark green for low proficiency).<br>
+* If multiple duplicate skill names are entered, HackNet will only take the skill with the highest proficiency. 
 </div>
 
 Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com g/johndoe123`
 * `add n/Betsy Crowe e/betsycrowe@example.com g/betsycoder p/1234567 t/gmail plugin, Sublime Text dev s/`
+* `add n/John Doe p/98765432 e/johnd@example.com g/johndoe123 s/C_90, C_2, C_22` will result in `C_90` as it has the highest value.
 
 ### Editing any number of person(s): `edit`
 
@@ -171,6 +173,7 @@ Format: `edit INDEX [INDEX…] [-r] [n/NAME] [p/PHONE] [e/EMAIL] [g/GITHUB_USERN
 * When editing multiple persons, only `[t/TEAM…]` and `[s/SKILLNAME_SKILLPROFICENCY…]` will take effect. Other arguments such as `NAME` and `PHONE` will be silently ignored.
 * When at least one of the indices provided are invalid for batch edit, HackNet informs that there was an error in the indices, but still delivers the modification for the indices that are valid.
 * In the unlikely case that same index is present multiple times for `INDEX [INDEX…]`, HackNet will still successfully execute the edit command as long as the index is valid.
+* If multiple duplicate skill names are entered, HackNet will only take the skill with the highest proficiency.
 
 Examples:
 * `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
@@ -178,6 +181,7 @@ Examples:
 * `edit 2 t/HackNet s/` Appends the team `Hacknet` to the 2nd person and keep the current skills.
 * `edit 2 3 s/ t/GoogleProject, Hackathon2022` Does not change the skills of 2nd and 3rd person in the list, and appends`GoogleProject` and `Hackathon2022` to the list of teams they belong to.
 * `edit 1 2 3 -r s/Java_100, Python_80, t/` Edits the skills of the 1st, 2nd and 3rd person to be `java` and `python` only with proficiency of 100 and 80. The exiting teams are cleared as well.
+* `edit 1 s/C_90, C_2, C_11` will result in the 1st person in the list having skill `C` with proficiency `90` as it is the highest value.
 
 ### Deleting a person: `delete`
 

--- a/docs/team/tzhan98.md
+++ b/docs/team/tzhan98.md
@@ -36,6 +36,7 @@ Given below are my contributions to the project.
   * Add input validation for `Github username` such that it complies with actual Github username rules [#147](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/147)
   * Change HackNet to allow for duplicate `name` fields but reject any command that try to add/edit a duplicate or existing `Github username`, `phone number` or `email` [#154](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/154)
   * Add length checks for `email`, `team` and `skill` [#167](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/167)
+  * Fix duplicate `Skill` tags during **multiple** `Skill` entry inputs (Separate issue from [#130](https://github.com/AY2122S2-CS2103T-W13-3/tp/issues/130))  [#181](https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/181)
 
 * **Documentation**:
   * User Guide:

--- a/src/main/java/seedu/address/model/team/SkillSet.java
+++ b/src/main/java/seedu/address/model/team/SkillSet.java
@@ -22,7 +22,7 @@ public class SkillSet {
      */
     public SkillSet(Set<Skill> skillSet) {
         requireAllNonNull(skillSet);
-        this.skillSet = skillSet;
+        this.skillSet = removeDuplicates(skillSet);
     }
 
     /**
@@ -31,7 +31,28 @@ public class SkillSet {
      */
     public SkillSet(SkillSet skillSet) {
         requireAllNonNull(skillSet);
-        this.skillSet = skillSet.getSkillSet();
+        this.skillSet = removeDuplicates(skillSet.getSkillSet());
+    }
+
+    /**
+     * Returns Set of Skills without duplicated skills. Will always take the largest skill proficiency if
+     * duplicated skill is given.
+     * @param skillSetToTest set of skills to test for
+     * @return unique set of skills
+     */
+    public Set<Skill> removeDuplicates(Set<Skill> skillSetToTest) {
+        SkillSet skillSet = new SkillSet();
+        for (Skill skill : skillSetToTest) {
+            if (skillSet.hasSkill(skill)) {
+                if (skill.skillProficiency > skillSet.getSkillProficiency(skill)) {
+                    skillSet.removeSkill(skill);
+                    skillSet.add(skill);
+                }
+            } else {
+                skillSet.add(skill);
+            }
+        }
+        return skillSet.getSkillSet();
     }
 
     /**

--- a/src/test/java/seedu/address/model/team/SkillSetTest.java
+++ b/src/test/java/seedu/address/model/team/SkillSetTest.java
@@ -13,11 +13,20 @@ import static seedu.address.testutil.TypicalSkills.SKILL_LINUX_60;
 import static seedu.address.testutil.TypicalSkills.SKILL_PYTHON_30;
 import static seedu.address.testutil.TypicalSkills.getTypicalSkillSet;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 public class SkillSetTest {
 
+
     private SkillSet skillSet1 = getTypicalSkillSet();
+    private Skill java100 = new Skill("Java", 100);
+    private Skill java90 = new Skill("Java", 90);
+    private Skill python100 = new Skill("python", 100);
+    private Skill c20 = new Skill("C", 20);
+    private Skill c1 = new Skill("C");
     private SkillSet skillSet2 = new SkillSet();
     private SkillSet skillSet3 = new SkillSet();
 
@@ -59,5 +68,18 @@ public class SkillSetTest {
     public void getSkill() {
         assertEquals(SKILL_C_20, skillSet1.getSkill(new Skill("C")));
         assertNull(skillSet1.getSkill(SKILL_BASH_70));
+    }
+
+    @Test
+    public void removeDuplicates() {
+        Set<Skill> duplicatedSet = new HashSet<>();
+        duplicatedSet.add(c1);
+        duplicatedSet.add(c1);
+        duplicatedSet.add(c20);
+        duplicatedSet.add(java90);
+        duplicatedSet.add(java100);
+        skillSet3.add(c20);
+        skillSet3.add(java100);
+        assertEquals(new SkillSet(duplicatedSet), skillSet3);
     }
 }

--- a/src/test/java/seedu/address/model/team/SkillSetTest.java
+++ b/src/test/java/seedu/address/model/team/SkillSetTest.java
@@ -73,11 +73,11 @@ public class SkillSetTest {
     @Test
     public void removeDuplicates() {
         Set<Skill> duplicatedSet = new HashSet<>();
-        duplicatedSet.add(c1);
+        duplicatedSet.add(java100);
         duplicatedSet.add(c1);
         duplicatedSet.add(c20);
+        duplicatedSet.add(c1);
         duplicatedSet.add(java90);
-        duplicatedSet.add(java100);
         skillSet3.add(c20);
         skillSet3.add(java100);
         assertEquals(new SkillSet(duplicatedSet), skillSet3);


### PR DESCRIPTION
Fix duplicated skill during input of **multiple** `skill` entries

Previous issue https://github.com/AY2122S2-CS2103T-W13-3/tp/pull/140 prevented duplicate `skill` input in **single** entries.
eg. 
current list has `Alex` in the first index and he has `C_70` and `edit 1 C_20` argument was given.
result: `Alex C_20` instead of `Alex C_70 C_20`

It did not take into the case where the input was `C_20, C_50, C_80`.
so an incorrect output `Alex C_20, C_50, C_80` will be shown on the GUI

Current PR fixes this issue and will only take the largest unique skill proficiency in the case where duplicate skills are given.
`edit 1 C_20, C_50, C_80` will result in `edit 1 C_80` in the background 

Thanks to @Jiaaa-yang for spotting the bug!