### PR TITLE
Remove placeholder text in DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -533,8 +533,7 @@ testers are expected to do more *exploratory* testing.
 
 1. Dealing with missing/corrupted data files
 
-   1. _{explain how to simulate a missing/corrupted file, and the expected behavior}_
-   2. Delete the first line containing `{` in the data file `data/addressbook.json`.
-   3. Start the application and exit right after.
+   1. Delete the first line containing `{` in the data file `data/addressbook.json`.
+   2. Start the application and exit right after.
 
     Expected: Data from data file is cleared and contains no entry.

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -376,7 +376,7 @@ Priorities: High (must have) - A, Medium (nice to have) - B, Low (unlikely to ha
 
       Use case ends.
 
-**Use case: UC02 - View contact's portfolio**
+<ins>**Use case: UC02 - View contact's portfolio**</ins>
 
 **MSS**
 1. User <ins>adds a contact (UC01)</ins> with a specific GitHub username.
@@ -477,7 +477,6 @@ Priorities: High (must have) - A, Medium (nice to have) - B, Low (unlikely to ha
 9. HackNet must be free of charge and open sourced.
 10. HackNet must be able to run after downloading and not require installation.
 
-*{More to be added}*
 
 ### Glossary
 
@@ -513,7 +512,6 @@ testers are expected to do more *exploratory* testing.
    1. Re-launch the app by double-clicking the jar file.<br>
        Expected: The most recent window size and location is retained.
 
-1. _{ more test cases …​ }_
 
 ### Deleting a person
 
@@ -530,12 +528,13 @@ testers are expected to do more *exploratory* testing.
    1. Other incorrect delete commands to try: `delete`, `delete x`, `...` (where x is larger than the list size)<br>
       Expected: Similar to previous.
 
-1. _{ more test cases …​ }_
 
 ### Saving data
 
 1. Dealing with missing/corrupted data files
 
    1. _{explain how to simulate a missing/corrupted file, and the expected behavior}_
+   2. Delete the first line containing `{` in the data file `data/addressbook.json`.
+   3. Start the application and exit right after.
 
-1. _{ more test cases …​ }_
+    Expected: Data from data file is cleared and contains no entry.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,7 +8,7 @@ header_pages:
 
 markdown: kramdown
 
-repository: "se-edu/addressbook-level3"
+repository: "AY2122S2-CS2103T-W13-3/tp"
 github_icon: "images/github-icon.png"
 
 plugins:


### PR DESCRIPTION
Fix some minor bugs in DG:
1. Remove placeholder text
2. Point GitHub link to current repo